### PR TITLE
Add function to shutdown DS interfaces during network config

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -839,9 +839,13 @@ func (arena *Arena) setupNetwork(teams [6]*model.Team, isPreload bool) {
 			log.Printf("Failed to configure team WiFi: %s", err.Error())
 		}
 		go func() {
+			network.Downredscc()
+			network.Downbluescc()
 			if err := arena.networkSwitch.ConfigureTeamEthernet(teams); err != nil {
 				log.Printf("Failed to configure team Ethernet: %s", err.Error())
 			}
+			network.Upredscc()
+			network.Upbluescc()
 		}()
 	}
 }

--- a/field/arena.go
+++ b/field/arena.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"reflect"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/Team254/cheesy-arena/game"
@@ -54,6 +56,8 @@ type Arena struct {
 	EventSettings    *model.EventSettings
 	accessPoint      network.AccessPoint
 	networkSwitch    *network.Switch
+	redSCC           *network.SCCSwitch
+	blueSCC          *network.SCCSwitch
 	Plc              plc.Plc
 	TbaClient        *partner.TbaClient
 	NexusClient      *partner.NexusClient
@@ -183,6 +187,10 @@ func (arena *Arena) LoadSettings() error {
 		accessPointWifiStatuses,
 	)
 	arena.networkSwitch = network.NewSwitch(settings.SwitchAddress, settings.SwitchPassword)
+	sccUpCommands := strings.Split(settings.SCCUpCommands, "\n")
+	sccDownCommands := strings.Split(settings.SCCDownCommands, "\n")
+	arena.redSCC = network.NewSCCSwitch(settings.RedSCCAddress, settings.SCCUsername, settings.SCCPassword, sccUpCommands, sccDownCommands)
+	arena.blueSCC = network.NewSCCSwitch(settings.BlueSCCAddress, settings.SCCUsername, settings.SCCPassword, sccUpCommands, sccDownCommands)
 	arena.Plc.SetAddress(settings.PlcAddress)
 	arena.TbaClient = partner.NewTbaClient(settings.TbaEventCode, settings.TbaSecretId, settings.TbaSecret)
 	arena.NexusClient = partner.NewNexusClient(settings.TbaEventCode)
@@ -821,6 +829,25 @@ func (arena *Arena) preLoadNextMatch() {
 	arena.TeamSigns.SetNextMatchTeams(nextMatch)
 }
 
+// Enable or disable the team ethernet ports on both SCCs
+func (arena *Arena) setSCCEthernetEnabled(enabled bool) {
+	if arena.EventSettings.SCCManagementEnabled {
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		configureSCC := func(scc *network.SCCSwitch, name string) {
+			defer wg.Done()
+			err := scc.SetTeamEthernetEnabled(enabled)
+			if err != nil {
+				log.Printf("Failed to set %s SCC enabled state to %t: %s", name, enabled, err.Error())
+			}
+		}
+		go configureSCC(arena.redSCC, "red")
+		go configureSCC(arena.blueSCC, "blue")
+		wg.Wait()
+	}
+}
+
 // Asynchronously reconfigures the networking hardware for the new set of teams.
 func (arena *Arena) setupNetwork(teams [6]*model.Team, isPreload bool) {
 	if isPreload {
@@ -839,13 +866,11 @@ func (arena *Arena) setupNetwork(teams [6]*model.Team, isPreload bool) {
 			log.Printf("Failed to configure team WiFi: %s", err.Error())
 		}
 		go func() {
-			network.Downredscc()
-			network.Downbluescc()
+			arena.setSCCEthernetEnabled(false)
 			if err := arena.networkSwitch.ConfigureTeamEthernet(teams); err != nil {
 				log.Printf("Failed to configure team Ethernet: %s", err.Error())
 			}
-			network.Upredscc()
-			network.Upbluescc()
+			arena.setSCCEthernetEnabled(true)
 		}()
 	}
 }

--- a/field/arena_notifiers.go
+++ b/field/arena_notifiers.go
@@ -92,6 +92,8 @@ func (arena *Arena) generateArenaStatusMessage() any {
 		CanStartMatch         bool
 		AccessPointStatus     string
 		SwitchStatus          string
+		RedSCCStatus          string
+		BlueSCCStatus         string
 		PlcIsHealthy          bool
 		FieldEStop            bool
 		PlcArmorBlockStatuses map[string]bool
@@ -102,6 +104,8 @@ func (arena *Arena) generateArenaStatusMessage() any {
 		arena.checkCanStartMatch() == nil,
 		arena.accessPoint.Status,
 		arena.networkSwitch.Status,
+		arena.redSCC.Status,
+		arena.blueSCC.Status,
 		arena.Plc.IsHealthy(),
 		arena.Plc.GetFieldEStop(),
 		arena.Plc.GetArmorBlockStatuses(),

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/Team254/cheesy-arena
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.9
 
 require (
 	github.com/dchest/uniuri v1.2.0
@@ -17,6 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/goburrow/serial v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/crypto v0.38.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/Team254/cheesy-arena
 
-go 1.23.0
-
-toolchain go1.23.9
+go 1.22
 
 require (
 	github.com/dchest/uniuri v1.2.0
@@ -19,7 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/goburrow/serial v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,9 +32,13 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
 go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
+golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
 golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -32,13 +32,13 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
 go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
-golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
-golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
+golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
+golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -5,13 +5,37 @@
 
 package model
 
-import "github.com/Team254/cheesy-arena/game"
+import (
+	"strings"
+
+	"github.com/Team254/cheesy-arena/game"
+)
 
 type PlayoffType int
 
 const (
 	DoubleEliminationPlayoff PlayoffType = iota
 	SingleEliminationPlayoff
+)
+
+// Configured here to avoid circular import dependencies.
+var (
+	sccDefaultUpCommands = []string{
+		"config terminal",
+		"interface range gigabitEthernet 1/2-4",
+		"no shutdown",
+		"exit",
+		"exit",
+		"exit",
+	}
+	sccDefaultDownCommands = []string{
+		"config terminal",
+		"interface range gigabitEthernet 1/2-4",
+		"shutdown",
+		"exit",
+		"exit",
+		"exit",
+	}
 )
 
 type EventSettings struct {
@@ -34,6 +58,13 @@ type EventSettings struct {
 	ApChannel                   int
 	SwitchAddress               string
 	SwitchPassword              string
+	SCCManagementEnabled        bool
+	RedSCCAddress               string
+	BlueSCCAddress              string
+	SCCUsername                 string
+	SCCPassword                 string
+	SCCUpCommands               string
+	SCCDownCommands             string
 	PlcAddress                  string
 	AdminPassword               string
 	TeamSignRed1Id              int
@@ -76,6 +107,8 @@ func (database *Database) GetEventSettings() (*EventSettings, error) {
 		SelectionShowUnpickedTeams:  true,
 		TbaDownloadEnabled:          true,
 		ApChannel:                   36,
+		SCCUpCommands:               strings.Join(sccDefaultUpCommands, "\n"),
+		SCCDownCommands:             strings.Join(sccDefaultDownCommands, "\n"),
 		WarmupDurationSec:           game.MatchTiming.WarmupDurationSec,
 		AutoDurationSec:             game.MatchTiming.AutoDurationSec,
 		PauseDurationSec:            game.MatchTiming.PauseDurationSec,

--- a/model/event_settings_test.go
+++ b/model/event_settings_test.go
@@ -26,6 +26,8 @@ func TestEventSettingsReadWrite(t *testing.T) {
 			SelectionShowUnpickedTeams:  true,
 			TbaDownloadEnabled:          true,
 			ApChannel:                   36,
+			SCCUpCommands:               "config terminal\ninterface range gigabitEthernet 1/2-4\nno shutdown\nexit\nexit\nexit",
+			SCCDownCommands:             "config terminal\ninterface range gigabitEthernet 1/2-4\nshutdown\nexit\nexit\nexit",
 			WarmupDurationSec:           0,
 			AutoDurationSec:             15,
 			PauseDurationSec:            3,

--- a/network/sccswitch.go
+++ b/network/sccswitch.go
@@ -1,3 +1,8 @@
+// Copyright 2025 Team 254. All Rights Reserved.
+// Author: pat@patfairbank.com (Patrick Fairbank)
+//
+// Methods for configuring an SCC Switch via SSH.
+
 package network
 
 import (

--- a/network/sccswitch.go
+++ b/network/sccswitch.go
@@ -1,0 +1,195 @@
+package network
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func runSSHCommands(host, username, password string, commands []string) error {
+	config := &ssh.ClientConfig{
+		User: username,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(password),
+		},
+		HostKeyCallback: ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			// Dont't verify the host key, just accept it.
+			return nil
+		}),
+		Timeout: 5 * time.Second, // Adjust timeout as needed
+	}
+
+	client, err := ssh.Dial("tcp", net.JoinHostPort(host, "22"), config)
+	if err != nil {
+		return fmt.Errorf("failed to dial SSH: %w", err)
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return fmt.Errorf("failed to create SSH session: %w", err)
+	}
+	defer session.Close()
+
+	modes := ssh.TerminalModes{
+		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
+		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
+	}
+
+	if err := session.RequestPty("xterm", 80, 40, modes); err != nil {
+		return fmt.Errorf("failed to request pseudo terminal: %w", err)
+	}
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	stderr, err := session.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+
+	if err := session.Shell(); err != nil {
+		return fmt.Errorf("failed to start shell: %w", err)
+	}
+
+	// Execute commands
+	for _, cmd := range commands {
+		_, err = stdin.Write([]byte(cmd + "\n"))
+		if err != nil {
+			return fmt.Errorf("failed to write command '%s' to stdin: %w", cmd, err)
+		}
+		// Add a small delay to allow the command to execute and output to be processed
+		time.Sleep(500 * time.Millisecond) // Adjust as needed
+	}
+
+	// Send the exit commands
+	_, err = stdin.Write([]byte("exit\n"))
+	if err != nil {
+		return fmt.Errorf("failed to write 'exit' to stdin: %w", err)
+	}
+	_, err = stdin.Write([]byte("exit\n"))
+	if err != nil {
+		return fmt.Errorf("failed to write 'exit' to stdin: %w", err)
+	}
+
+	// Read output (optional)
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := stdout.Read(buf)
+			if err != nil {
+				return
+			}
+			fmt.Print(string(buf[:n]))
+		}
+	}()
+
+	// Read errors (optional)
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := stderr.Read(buf)
+			if err != nil {
+				return
+			}
+			fmt.Fprintf(log.Default().Writer(), "stderr: %s", string(buf[:n]))
+		}
+	}()
+
+	// Wait for the session to close
+	return session.Wait()
+}
+
+func Downredscc() {
+	host := "10.0.100.48"  // Client IP address
+	username := "admin"    // SSH Username
+	password := "1234Five" // SSH Password
+
+	commands := []string{
+		"config terminal",
+		"interface range gigabitEthernet 1/2-4",
+		"shutdown",
+		"exit",
+		"exit",
+	}
+
+	err := runSSHCommands(host, username, password, commands)
+	if err != nil {
+		log.Fatalf("Failed to run commands: %v", err)
+	}
+
+	fmt.Println("Successfully executed commands on", host)
+}
+
+func Downbluescc() {
+	host := "10.0.100.49"  // Client IP address
+	username := "admin"    // SSH Username
+	password := "1234Five" // SSH Password
+
+	commands := []string{
+		"config terminal",
+		"interface range gigabitEthernet 1/2-4",
+		"shutdown",
+		"exit",
+		"exit",
+	}
+
+	err := runSSHCommands(host, username, password, commands)
+	if err != nil {
+		log.Fatalf("Failed to run commands: %v", err)
+	}
+
+	fmt.Println("Successfully executed commands on", host)
+}
+
+func Upredscc() {
+	host := "10.0.100.48"  // Client IP address
+	username := "admin"    // SSH Username
+	password := "1234Five" // SSH Password
+
+	commands := []string{
+		"config terminal",
+		"interface range gigabitEthernet 1/2-4",
+		"no shutdown",
+		"exit",
+		"exit",
+	}
+
+	err := runSSHCommands(host, username, password, commands)
+	if err != nil {
+		log.Fatalf("Failed to run commands: %v", err)
+	}
+
+	fmt.Println("Successfully executed commands on", host)
+}
+
+func Upbluescc() {
+	host := "10.0.100.49"  // Client IP address
+	username := "admin"    // SSH Username
+	password := "1234Five" // SSH Password
+
+	commands := []string{
+		"config terminal",
+		"interface range gigabitEthernet 1/2-4",
+		"no shutdown",
+		"exit",
+		"exit",
+	}
+
+	err := runSSHCommands(host, username, password, commands)
+	if err != nil {
+		log.Fatalf("Failed to run commands: %v", err)
+	}
+
+	fmt.Println("Successfully executed commands on", host)
+}

--- a/network/sccswitch.go
+++ b/network/sccswitch.go
@@ -1,195 +1,136 @@
 package network
 
 import (
+	"bytes"
 	"fmt"
-	"log"
 	"net"
+	"strconv"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
 )
 
-func runSSHCommands(host, username, password string, commands []string) error {
-	config := &ssh.ClientConfig{
-		User: username,
-		Auth: []ssh.AuthMethod{
-			ssh.Password(password),
-		},
-		HostKeyCallback: ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
-			// Dont't verify the host key, just accept it.
-			return nil
-		}),
-		Timeout: 5 * time.Second, // Adjust timeout as needed
+const (
+	sccSwitchConnectTimeoutSec = 5
+	sccSwitchConfigTimeoutSec  = 5
+	sccSwitchSSHPort           = 22
+)
+
+type SCCSwitch struct {
+	address                string
+	port                   int
+	username               string
+	password               string
+	mutex                  sync.Mutex
+	connectTimeoutDuration time.Duration
+	configTimeoutDuration  time.Duration
+	upCommands             []string
+	downCommands           []string
+	Status                 string
+}
+
+func NewSCCSwitch(address, username, password string, upCommands, downCommands []string) *SCCSwitch {
+	return &SCCSwitch{
+		address:                address,
+		port:                   sccSwitchSSHPort,
+		username:               username,
+		password:               password,
+		connectTimeoutDuration: sccSwitchConnectTimeoutSec * time.Second,
+		configTimeoutDuration:  sccSwitchConfigTimeoutSec * time.Second,
+		upCommands:             upCommands,
+		downCommands:           downCommands,
+		Status:                 "UNKNOWN",
+	}
+}
+
+func (scc *SCCSwitch) SetTeamEthernetEnabled(enabled bool) error {
+	scc.mutex.Lock()
+	defer scc.mutex.Unlock()
+
+	scc.Status = "CONFIGURING"
+
+	commandSequence := scc.downCommands
+	if enabled {
+		commandSequence = scc.upCommands
 	}
 
-	client, err := ssh.Dial("tcp", net.JoinHostPort(host, "22"), config)
+	_, err := scc.runCommandSequence(commandSequence)
 	if err != nil {
-		return fmt.Errorf("failed to dial SSH: %w", err)
+		scc.Status = "ERROR"
+		return fmt.Errorf("failed to set team ethernet state: %w", err)
+	}
+
+	if enabled {
+		scc.Status = "ACTIVE"
+	} else {
+		scc.Status = "DISABLED"
+	}
+
+	return nil
+}
+
+// Logs into the switch via SSH and runs the given commands in sequence.
+// Returns the output of the commands or an error if the operation fails.
+func (scc *SCCSwitch) runCommandSequence(commands []string) (string, error) {
+	// Open an SSH connection to the switch.
+	sshConfig := &ssh.ClientConfig{
+		User: scc.username,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(scc.password),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // Allow any host key for simplicity
+		Timeout:         sccSwitchConnectTimeoutSec * time.Second,
+	}
+	client, err := ssh.Dial("tcp", net.JoinHostPort(scc.address, strconv.Itoa(scc.port)), sshConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to SSH: %w", err)
 	}
 	defer client.Close()
 
+	// Create an interactive session to run commands
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %w", err)
+		return "", fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer session.Close()
 
-	modes := ssh.TerminalModes{
-		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
-		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
-	}
+	// Capture the session output
+	var outputBuffer bytes.Buffer
+	session.Stdout = &outputBuffer
+	session.Stderr = &outputBuffer
 
-	if err := session.RequestPty("xterm", 80, 40, modes); err != nil {
-		return fmt.Errorf("failed to request pseudo terminal: %w", err)
-	}
-
-	stdin, err := session.StdinPipe()
+	inputPipe, err := session.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdin pipe: %w", err)
+		return "", fmt.Errorf("failed to create input pipe: %w", err)
 	}
 
-	stdout, err := session.StdoutPipe()
+	// Launch the switch's interactive shell
+	err = session.Shell()
 	if err != nil {
-		return fmt.Errorf("failed to create stdout pipe: %w", err)
+		return "", fmt.Errorf("failed to start shell: %w", err)
 	}
 
-	stderr, err := session.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("failed to create stderr pipe: %w", err)
+	// Submit the commands to the switch
+	for _, command := range commands {
+		if _, err := fmt.Fprintln(inputPipe, command); err != nil {
+			return "", fmt.Errorf("failed to write command to switch: %w", err)
+		}
 	}
 
-	if err := session.Shell(); err != nil {
-		return fmt.Errorf("failed to start shell: %w", err)
-	}
-
-	// Execute commands
-	for _, cmd := range commands {
-		_, err = stdin.Write([]byte(cmd + "\n"))
+	// Wait for the remote to process the commands and exit the shell
+	done := make(chan error, 1)
+	go func() {
+		done <- session.Wait()
+	}()
+	select {
+	case err := <-done:
 		if err != nil {
-			return fmt.Errorf("failed to write command '%s' to stdin: %w", cmd, err)
+			return "", fmt.Errorf("failed to run command sequence: %w", err)
 		}
-		// Add a small delay to allow the command to execute and output to be processed
-		time.Sleep(500 * time.Millisecond) // Adjust as needed
+	case <-time.After(scc.connectTimeoutDuration):
+		return "", fmt.Errorf("timed out waiting for command sequence to complete")
 	}
 
-	// Send the exit commands
-	_, err = stdin.Write([]byte("exit\n"))
-	if err != nil {
-		return fmt.Errorf("failed to write 'exit' to stdin: %w", err)
-	}
-	_, err = stdin.Write([]byte("exit\n"))
-	if err != nil {
-		return fmt.Errorf("failed to write 'exit' to stdin: %w", err)
-	}
-
-	// Read output (optional)
-	go func() {
-		buf := make([]byte, 4096)
-		for {
-			n, err := stdout.Read(buf)
-			if err != nil {
-				return
-			}
-			fmt.Print(string(buf[:n]))
-		}
-	}()
-
-	// Read errors (optional)
-	go func() {
-		buf := make([]byte, 4096)
-		for {
-			n, err := stderr.Read(buf)
-			if err != nil {
-				return
-			}
-			fmt.Fprintf(log.Default().Writer(), "stderr: %s", string(buf[:n]))
-		}
-	}()
-
-	// Wait for the session to close
-	return session.Wait()
-}
-
-func Downredscc() {
-	host := "10.0.100.48"  // Client IP address
-	username := "admin"    // SSH Username
-	password := "1234Five" // SSH Password
-
-	commands := []string{
-		"config terminal",
-		"interface range gigabitEthernet 1/2-4",
-		"shutdown",
-		"exit",
-		"exit",
-	}
-
-	err := runSSHCommands(host, username, password, commands)
-	if err != nil {
-		log.Fatalf("Failed to run commands: %v", err)
-	}
-
-	fmt.Println("Successfully executed commands on", host)
-}
-
-func Downbluescc() {
-	host := "10.0.100.49"  // Client IP address
-	username := "admin"    // SSH Username
-	password := "1234Five" // SSH Password
-
-	commands := []string{
-		"config terminal",
-		"interface range gigabitEthernet 1/2-4",
-		"shutdown",
-		"exit",
-		"exit",
-	}
-
-	err := runSSHCommands(host, username, password, commands)
-	if err != nil {
-		log.Fatalf("Failed to run commands: %v", err)
-	}
-
-	fmt.Println("Successfully executed commands on", host)
-}
-
-func Upredscc() {
-	host := "10.0.100.48"  // Client IP address
-	username := "admin"    // SSH Username
-	password := "1234Five" // SSH Password
-
-	commands := []string{
-		"config terminal",
-		"interface range gigabitEthernet 1/2-4",
-		"no shutdown",
-		"exit",
-		"exit",
-	}
-
-	err := runSSHCommands(host, username, password, commands)
-	if err != nil {
-		log.Fatalf("Failed to run commands: %v", err)
-	}
-
-	fmt.Println("Successfully executed commands on", host)
-}
-
-func Upbluescc() {
-	host := "10.0.100.49"  // Client IP address
-	username := "admin"    // SSH Username
-	password := "1234Five" // SSH Password
-
-	commands := []string{
-		"config terminal",
-		"interface range gigabitEthernet 1/2-4",
-		"no shutdown",
-		"exit",
-		"exit",
-	}
-
-	err := runSSHCommands(host, username, password, commands)
-	if err != nil {
-		log.Fatalf("Failed to run commands: %v", err)
-	}
-
-	fmt.Println("Successfully executed commands on", host)
+	return outputBuffer.String(), nil
 }

--- a/static/js/match_play.js
+++ b/static/js/match_play.js
@@ -264,6 +264,8 @@ const handleArenaStatus = function (data) {
 
   $("#accessPointStatus").attr("data-status", data.AccessPointStatus);
   $("#switchStatus").attr("data-status", data.SwitchStatus);
+  $("#redSCCStatus").attr("data-status", data.RedSCCStatus);
+  $("#blueSCCStatus").attr("data-status", data.BlueSCCStatus);
 
   if (data.PlcIsHealthy) {
     $("#plcStatus").text("Connected");

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -104,6 +104,11 @@ UI for controlling match play and viewing team connection and field status.
           <p>
             <span class="badge badge-status" id="accessPointStatus">Access Point</span><br/>
             <span class="badge badge-status" id="switchStatus">Switch</span>
+            {{if .EventSettings.SCCManagementEnabled}}
+            <br/>
+            <span class="badge badge-status" id="redSCCStatus">Red SCC</span><br/>
+            <span class="badge badge-status" id="blueSCCStatus">Blue SCC</span>
+            {{end}}
           </p>
           {{end}}
           {{if .PlcIsEnabled}}

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -300,6 +300,56 @@ UI for configuring event settings.
               </div>
             </fieldset>
             <fieldset class="mb-4">
+              <legend>SCC Switch</legend>
+              <p>Enable this setting if you have an SSH-capable managed switch in your SCCs and want to run commands
+                to disable team ethernet ports while network reconfiguration is in progress. This setting only works
+                if advanced network security is enabled above.</p>
+              <div class="row mb-3">
+                <label class="col-lg-8 control-label"
+                  for="sccManagementEnabled">Enable SCC switch management</label>
+                <div class="col-lg-1 checkbox">
+                  <input type="checkbox" id="sccManagementEnabled"
+                    name="sccManagementEnabled" {{if .SCCManagementEnabled}} checked{{end}}>
+                </div>
+              </div>
+              <div class="row mb-3">
+                <label class="col-lg-6 control-label">Red SCC Address</label>
+                <div class="col-lg-6">
+                  <input type="text" class="form-control" name="redSCCAddress" value="{{.RedSCCAddress}}" placeholder="10.0.100.48">
+                </div>
+              </div>
+              <div class="row mb-3">
+                <label class="col-lg-6 control-label">Blue SCC Address</label>
+                <div class="col-lg-6">
+                  <input type="text" class="form-control" name="blueSCCAddress" value="{{.BlueSCCAddress}}" placeholder="10.0.100.49">
+                </div>
+              </div>
+              <div class="row mb-3">
+                <label class="col-lg-6 control-label">SCC Username</label>
+                <div class="col-lg-6">
+                  <input type="text" class="form-control" name="sccUsername" value="{{.SCCUsername}}" placeholder="admin">
+                </div>
+              </div>
+              <div class="row mb-3">
+                <label class="col-lg-6 control-label">SCC Password</label>
+                <div class="col-lg-6">
+                  <input type="password" class="form-control" name="sccPassword" value="{{.SCCPassword}}">
+                </div>
+              </div>
+              <div class="row mb-3">
+                <label class="col-lg-6 control-label">SCC Enable Commands</label>
+                <div class="col-lg-6">
+                  <textarea class="form-control" name="sccUpCommands" rows="8">{{.SCCUpCommands}}</textarea>
+                </div>
+              </div>
+              <div class="row mb-3">
+                <label class="col-lg-6 control-label">SCC Disable Commands</label>
+                <div class="col-lg-6">
+                  <textarea class="form-control" name="sccDownCommands" rows="8">{{.SCCDownCommands}}</textarea>
+                </div>
+              </div>
+            </fieldset>
+            <fieldset class="mb-4">
               <legend>PLC</legend>
               <div class="row mb-3">
                 <label class="col-lg-6 control-label">PLC Address</label>

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -86,6 +86,13 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.ApChannel, _ = strconv.Atoi(r.PostFormValue("apChannel"))
 	eventSettings.SwitchAddress = r.PostFormValue("switchAddress")
 	eventSettings.SwitchPassword = r.PostFormValue("switchPassword")
+	eventSettings.SCCManagementEnabled = r.PostFormValue("sccManagementEnabled") == "on"
+	eventSettings.RedSCCAddress = r.PostFormValue("redSCCAddress")
+	eventSettings.BlueSCCAddress = r.PostFormValue("blueSCCAddress")
+	eventSettings.SCCUsername = r.PostFormValue("sccUsername")
+	eventSettings.SCCPassword = r.PostFormValue("sccPassword")
+	eventSettings.SCCUpCommands = r.PostFormValue("sccUpCommands")
+	eventSettings.SCCDownCommands = r.PostFormValue("sccDownCommands")
 	eventSettings.PlcAddress = r.PostFormValue("plcAddress")
 	eventSettings.AdminPassword = r.PostFormValue("adminPassword")
 	eventSettings.TeamSignRed1Id, _ = strconv.Atoi(r.PostFormValue("teamSignRed1Id"))


### PR DESCRIPTION
Adds function to SSH into the SCC switches before network config begins and shutdown the DS ethernet interfaces.
Then SSH in again and run no shutdown on the same interfaces once network config completes.

This code is experimental but was tested at NCRI, it eliminated teams getting the wrong teams IP address when moving stations and massively reduced teams getting 169.254 link local addresses.

Massive thanks to Ian for cleaning this up.